### PR TITLE
Update Dockerfile

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 ENV LANG ru_RU.UTF-8
 ENV LANGUAGE ru_RU:ru
 ENV LC_ALL ru_RU.UTF-8
-
+// Ошибка в этой строке
 RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "client"
 
 # Начало основной стадии сборки


### PR DESCRIPTION
Ошибка в 34 строчке вызывает следующее
591.9 ИНФОРМАЦИЯ - [ЗагрузчикРелизов1С]: Достигнут лимит загружаемых версий 1
592.7 Не найден дистрибутив по шаблону: Технологическая платформа 1С:Предприятия \(64\-bit\) для Linux$
592.7 Попытка скачать дистрибутив с фильтром: Клиент 1С:Предприятия \(64\-bit\) для DEB-based Linux-систем$
593.6 ИНФОРМАЦИЯ - [СписокРелизов1С]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [ЗагрузчикРелизов1С]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [РаспаковщикРелизов1С]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [РаспаковщикКаталогаРелизов1С]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [СборщикКонфигураций1С]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [СборщикКонфигураций1СВКаталоге]: Инициализирован обработчик
593.7 ИНФОРМАЦИЯ - [ВыгрузкаКонфигурацииВГит]: Инициализирован обработчик
593.8 ИНФОРМАЦИЯ - [ВыгрузкаКаталогаКонфигурацииВГит]: Инициализирован обработчик
664.9 ИНФОРМАЦИЯ - [ЗагрузчикРелизов1С]: Версия "8.3.24.1368" от "23.01.2024" конфигурации "Технологическая платформа 8.3" уже существует в каталоге "/tmp/downloads/Platform83"
665.0 Не найден дистрибутив по шаблону: Клиент 1С:Предприятия \(64\-bit\) для DEB-based Linux-систем$
665.0 Ошибка: не удалось найти дистрибутив ни локально, ни удаленно.
------
Dockerfile:34
--------------------
  32 |     ENV LC_ALL ru_RU.UTF-8
  33 |     
  34 | >>> RUN /download.sh "$ONEC_USERNAME" "$ONEC_PASSWORD" "$ONEC_VERSION" "client"
  35 |     
  36 |     # Начало основной стадии сборки
--------------------
ERROR: failed to solve: process "/bin/sh -c /download.sh \"$ONEC_USERNAME\" \"$ONEC_PASSWORD\" \"$ONEC_VERSION\" \"client\"" did not complete successfully: exit code: 1
